### PR TITLE
We do need six.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     'setuptools',
+    'six',
 ]
 
 setup(
@@ -44,7 +45,6 @@ setup(
     namespace_packages=['gocept'],
     install_requires=install_requires,
     extras_require=dict(test=[
-        'mock',
     ]),
     entry_points=dict(console_scripts=[
         'gocept-jshint = gocept.jslint.util:run_jslint',


### PR DESCRIPTION
All transitive dependencies have dropped it in Python 3 already.