### PR TITLE
Fix output/encoding handling for python-3 (belongs to 8ef8473)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ CHANGES
 
 - Add support for Python 3.9.
 
+- Fix output/encoding handling for Python 3,
+  especially regarding the ``ignore`` setting.
+
 
 2.1 (2021-01-07)
 ----------------

--- a/src/gocept/jslint/case.py
+++ b/src/gocept/jslint/case.py
@@ -104,8 +104,8 @@ class TestCase(unittest.TestCase, metaclass=JSLintTestGenerator):
 
     def _filter_ignored_errors(self, output):
         result = []
-        for line in output.splitlines():
-            if self._error_summary.search(line.decode('utf-8')):
+        for line in output.decode('utf-8').splitlines():
+            if self._error_summary.search(line):
                 continue
             ignore = False
             for pattern in self.ignore:
@@ -114,5 +114,5 @@ class TestCase(unittest.TestCase, metaclass=JSLintTestGenerator):
                     break
             if ignore:
                 continue
-            result.append(line.decode('utf-8'))
+            result.append(line)
         return '\n'.join(result)

--- a/src/gocept/jslint/tests/test_case.py
+++ b/src/gocept/jslint/tests/test_case.py
@@ -47,6 +47,7 @@ class RunTest(unittest.TestCase):
 
         result = unittest.TestResult()
         Example('test_jslint_one.js').run(result)
+        self.assertFalse(result.errors)
         self.assertEqual(1, len(result.failures))
         traceback = result.failures[0][1]
         self.assertIn(
@@ -59,6 +60,7 @@ class RunTest(unittest.TestCase):
 
         result = unittest.TestResult()
         Example('test_jslint_one.js').run(result)
+        self.assertFalse(result.errors)
         self.assertEqual(0, len(result.failures))
 
     def test_ignored_errors_should_pass_test(self):
@@ -70,6 +72,7 @@ class RunTest(unittest.TestCase):
 
         result = unittest.TestResult()
         Example('test_jslint_one.js').run(result)
+        self.assertFalse(result.errors)
         self.assertEqual(0, len(result.failures))
 
     def test_nodejs_not_available_should_skip(self):
@@ -80,6 +83,7 @@ class RunTest(unittest.TestCase):
 
         result = unittest.TestResult()
         Example('test_jslint_one.js').run(result)
+        self.assertFalse(result.errors)
         self.assertEqual(1, len(result.skipped))
 
     def test_adding_predefined_variables(self):
@@ -91,4 +95,5 @@ class RunTest(unittest.TestCase):
 
         result = unittest.TestResult()
         Example('test_jslint_predefined.js').run(result)
+        self.assertFalse(result.errors)
         self.assertEqual(0, len(result.failures))


### PR DESCRIPTION
The previous spelling breaks in line 112 "if pattern in line" since pattern usually is text. Also it probably makes the most sense to decode once an be done with it.